### PR TITLE
Fix for Issue #7, generalizing multi-line schemas tests:

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The schema repo's REST server implementation uses Jetty. The defaults below will
     schema-repo.jetty.path=/schema-repo
     schema-repo.jetty.header.size=16384
     schema-repo.jetty.buffer.size=16384
+    schema-repo.jetty.stop-at-shutdown=true
+    schema-repo.jetty.graceful-shutdown=3000
     
 ## REST API Documentation
 

--- a/client/src/main/java/org/schemarepo/client/RESTRepositoryClient.java
+++ b/client/src/main/java/org/schemarepo/client/RESTRepositoryClient.java
@@ -101,6 +101,14 @@ public class RESTRepositoryClient implements Repository {
     return subjectList;
   }
 
+  /**
+   * This is a no-op for the RESTRepositoryClient
+   */
+  @Override
+  public void close() {
+    // no-op
+  }
+
   private class RESTSubject extends Subject {
 
     private RESTSubject(String name) {

--- a/common/src/main/java/org/schemarepo/CacheRepository.java
+++ b/common/src/main/java/org/schemarepo/CacheRepository.java
@@ -19,6 +19,7 @@
 package org.schemarepo;
 
 import javax.inject.Inject;
+import java.io.IOException;
 
 /**
  * CacheRepository is a {@link Repository} implementation that wraps another
@@ -39,8 +40,15 @@ import javax.inject.Inject;
  */
 public class CacheRepository implements Repository {
 
-  private final RepositoryCache cache;
   private final Repository repo;
+  private final RepositoryCache cache;
+
+  /**
+   * The runtimeID is a simple sanity check to validate that the repo that gets
+   * constructed by the dependency injection framework is the same that gets
+   * closed at the end of the runtime.
+   */
+  private final double runtimeID = Math.random();
 
   /**
    * Create a caching repository that wraps the provided repository using the
@@ -52,6 +60,7 @@ public class CacheRepository implements Repository {
   public CacheRepository(Repository repo, RepositoryCache cache) {
     this.repo = repo;
     this.cache = cache;
+    System.out.println("Constructed " + this.toString());
   }
 
   @Override
@@ -81,5 +90,23 @@ public class CacheRepository implements Repository {
       cache.add(s);
     }
     return subs;
+  }
+
+  /**
+   * Closes the inner repository that was passed in at construction time.
+   *
+   * @throws java.io.IOException if an I/O error occurs
+   */
+  @Override
+  public void close() throws IOException {
+    repo.close();
+    System.out.println("Closed " + this.toString());
+  }
+
+  public String toString() {
+    return "CacheRepository with the following properties:\n" +
+            "\trepo: " + repo.getClass().toString() + "\n" +
+            "\tcache: " + cache.getClass().toString() + "\n" +
+            "\truntimeID: " + runtimeID;
   }
 }

--- a/common/src/main/java/org/schemarepo/InMemoryRepository.java
+++ b/common/src/main/java/org/schemarepo/InMemoryRepository.java
@@ -52,6 +52,14 @@ public class InMemoryRepository implements Repository {
     return subjects.values();
   }
 
+  /**
+   * This is a no-op for the InMemoryRepository
+   */
+  @Override
+  public void close() {
+    // no-op
+  }
+
   private static class MemSubject extends Subject {
     private final InMemorySchemaEntryCache schemas = new InMemorySchemaEntryCache();
     private SchemaEntry latest = null;

--- a/common/src/main/java/org/schemarepo/LocalFileSystemRepository.java
+++ b/common/src/main/java/org/schemarepo/LocalFileSystemRepository.java
@@ -21,7 +21,6 @@ package org.schemarepo;
 import org.schemarepo.config.Config;
 
 import java.io.BufferedWriter;
-import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -64,7 +63,7 @@ import javax.inject.Named;
  * the name of which is the schema id followed by the postfix '.schema'.</li>
  *
  */
-public class LocalFileSystemRepository implements Repository, Closeable {
+public class LocalFileSystemRepository implements Repository {
 
   private static final String LOCKFILE = ".repo.lock";
   private static final String SUBJECT_PROPERTIES = "subject.properties";
@@ -472,20 +471,11 @@ public class LocalFileSystemRepository implements Repository, Closeable {
       }
     }
 
-    private final String endOfLine = System.getProperty("line.separator");
-
     private String readAllAsString(File file) throws FileNotFoundException {
       // a scanner that will read a whole file
-      Scanner s = new Scanner(file, "UTF-8").useDelimiter(endOfLine);
-      StringBuilder strBuilder = new StringBuilder();
+      Scanner s = new Scanner(file, "UTF-8").useDelimiter("\\A");
       try {
-        while (s.hasNext()) {
-          strBuilder.append(s.nextLine());
-          if (s.hasNext()) {
-            strBuilder.append(endOfLine);
-          }
-        }
-        return strBuilder.toString();
+        return s.next();
       } catch (NoSuchElementException e) {
         throw new RuntimeException(
             "file is empty: " + file.getAbsolutePath(), e);

--- a/common/src/main/java/org/schemarepo/ReadOnlyRepository.java
+++ b/common/src/main/java/org/schemarepo/ReadOnlyRepository.java
@@ -18,6 +18,7 @@
 
 package org.schemarepo;
 
+import java.io.IOException;
 import java.util.ArrayList;
 
 import javax.inject.Inject;
@@ -28,7 +29,7 @@ import javax.inject.Inject;
  * the {@link Repository}.<br/>
  * <br/>
  *
- * {@link #register(String, Map)}, {@link Subject#register(String)}
+ * {@link #register(String, SubjectConfig)}, {@link Subject#register(String)}
  * and {@link Subject#registerIfLatest(String, SchemaEntry)} throw
  * {@link IllegalStateException} if called.
  */
@@ -62,5 +63,15 @@ public class ReadOnlyRepository implements Repository {
       subjects.add(Subject.readOnly(sub));
     }
     return subjects;
+  }
+
+  /**
+   * Closes the inner repository that was passed in at construction time.
+   *
+   * @throws java.io.IOException if an I/O error occurs
+   */
+  @Override
+  public void close() throws IOException {
+    repo.close();
   }
 }

--- a/common/src/main/java/org/schemarepo/Repository.java
+++ b/common/src/main/java/org/schemarepo/Repository.java
@@ -18,6 +18,8 @@
 
 package org.schemarepo;
 
+import java.io.Closeable;
+
 /**
  * A {@link Repository} is a collection of {@link Subject}s. A {@link Subject}
  * can be looked up by name on a {@link Repository}, or registered.<br/>
@@ -29,7 +31,7 @@ package org.schemarepo;
  * <br/>
  *
  */
-public interface Repository {
+public interface Repository extends Closeable {
 
   /**
    * Attempt to create a Subject with the given name and validator.

--- a/common/src/main/java/org/schemarepo/config/Config.java
+++ b/common/src/main/java/org/schemarepo/config/Config.java
@@ -39,6 +39,8 @@ public class Config {
   public static final String JETTY_PATH = JETTY_PREFIX + "path";
   public static final String JETTY_HEADER_SIZE = JETTY_PREFIX + "header.size";
   public static final String JETTY_BUFFER_SIZE = JETTY_PREFIX + "buffer.size";
+  public static final String JETTY_STOP_AT_SHUTDOWN = JETTY_PREFIX + "stop-at-shutdown";
+  public static final String JETTY_GRACEFUL_SHUTDOWN = JETTY_PREFIX + "graceful-shutdown";
 
   // Local file system backend configs
   private static final String LOCAL_FILE_SYSTEM_PREFIX = GLOBAL_PREFIX + "local-file-system.";
@@ -66,6 +68,8 @@ public class Config {
     DEFAULTS.setProperty(JETTY_PATH, "/schema-repo");
     DEFAULTS.setProperty(JETTY_HEADER_SIZE, "16384");
     DEFAULTS.setProperty(JETTY_BUFFER_SIZE, "16384");
+    DEFAULTS.setProperty(JETTY_STOP_AT_SHUTDOWN, "true");
+    DEFAULTS.setProperty(JETTY_GRACEFUL_SHUTDOWN, "3000");
 
     // Zookeeper backend defaults
     DEFAULTS.setProperty(ZK_ENSEMBLE, "");

--- a/common/src/test/java/org/schemarepo/AbstractTestPersistentRepository.java
+++ b/common/src/test/java/org/schemarepo/AbstractTestPersistentRepository.java
@@ -1,0 +1,86 @@
+package org.schemarepo;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * This extension of {@link AbstractTestRepository} includes tests that close
+ * a schema repository and re-open it, to make sure persistence works correctly.
+ */
+public abstract class AbstractTestPersistentRepository<R extends Repository>
+        extends AbstractTestRepository<R> {
+  @Test
+  public void testWriteCloseRead() throws SchemaValidationException, IOException {
+    try {
+      repo.register("sub1", null).register("sc1");
+      repo.register("sub2", null).register("sc2");
+      repo.register("sub2", null).register("sc3");
+    } finally {
+      repo.close();
+    }
+    // Calling close() and createRepository() is like bouncing the repo, to ensure its state persists.
+    repo = createRepository();
+    try {
+      Subject s1 = repo.lookup("sub1");
+      Assert.assertNotNull(s1);
+      Subject s2 = repo.lookup("sub2");
+      Assert.assertNotNull(s2);
+
+      SchemaEntry e1 = s1.lookupBySchema("sc1");
+      Assert.assertNotNull(e1);
+      Assert.assertEquals("sc1", e1.getSchema());
+
+      SchemaEntry e2 = s2.lookupBySchema("sc2");
+      Assert.assertNotNull(e2);
+      Assert.assertEquals("sc2", e2.getSchema());
+
+      SchemaEntry e3 = s2.lookupBySchema("sc3");
+      Assert.assertNotNull(e3);
+      Assert.assertEquals("sc3", e3.getSchema());
+    } finally {
+      repo.close();
+    }
+  }
+
+  @Test
+  public void testWriteCloseReadMultiLineSchema() throws SchemaValidationException, IOException {
+    String endOfLine = System.getProperty("line.separator");
+
+    String multiLineSchema1 = "first line" + endOfLine + "second line";
+    String multiLineSchema2 = "first line" + endOfLine + "second line" + endOfLine;
+
+    try {
+      repo.register("sub1", null).register(multiLineSchema1);
+      repo.register("sub1", null).register(multiLineSchema2);
+    } finally {
+      repo.close();
+    }
+    // Calling close() and createRepository() is like bouncing the repo, to ensure its state persists.
+    repo = createRepository();
+    try {
+      Subject s1 = repo.lookup("sub1");
+      Assert.assertNotNull(s1);
+
+      SchemaEntry schemaEntry1ById = s1.lookupById("0");
+      Assert.assertNotNull(schemaEntry1ById);
+      Assert.assertEquals(multiLineSchema1, schemaEntry1ById.getSchema());
+
+      SchemaEntry schemaEntry1BySchema = s1.lookupBySchema(multiLineSchema1);
+      Assert.assertNotNull(schemaEntry1BySchema);
+      Assert.assertEquals(multiLineSchema1, schemaEntry1BySchema.getSchema());
+
+      SchemaEntry schemaEntry2ById = s1.lookupById("1");
+      Assert.assertNotNull(schemaEntry2ById);
+      Assert.assertEquals(multiLineSchema2, schemaEntry2ById.getSchema());
+
+      SchemaEntry schemaEntry2BySchema = s1.lookupBySchema(multiLineSchema2);
+      Assert.assertNotNull(schemaEntry2BySchema);
+      Assert.assertEquals(multiLineSchema2, schemaEntry2BySchema.getSchema());
+
+    } finally {
+      repo.close();
+    }
+  }
+}

--- a/common/src/test/java/org/schemarepo/AbstractTestRepository.java
+++ b/common/src/test/java/org/schemarepo/AbstractTestRepository.java
@@ -37,7 +37,7 @@ public abstract class AbstractTestRepository<R extends Repository> {
   private static final String BAR = "bar";
   private static final String BAZ = "baz";
 
-  private R repo;
+  protected R repo;
 
   protected abstract R createRepository();
 

--- a/common/src/test/java/org/schemarepo/TestLocalFileSystemRepository.java
+++ b/common/src/test/java/org/schemarepo/TestLocalFileSystemRepository.java
@@ -23,13 +23,11 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import junit.framework.Assert;
-
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestLocalFileSystemRepository extends AbstractTestRepository<LocalFileSystemRepository> {
+public class TestLocalFileSystemRepository extends AbstractTestPersistentRepository<LocalFileSystemRepository> {
   private static final String TEST_PATH = "target/test/TestLocalFileSystemRepository-paths/";
   private static final String REPO_PATH = "target/test/TestLocalFileSystemRepository/";
 
@@ -42,12 +40,12 @@ public class TestLocalFileSystemRepository extends AbstractTestRepository<LocalF
   @After
   public void cleanUp() throws IOException {
     getRepo().close();
+    // Clean up the repo's content
+    rmDir(new File(REPO_PATH));
   }
 
   @Override
   protected LocalFileSystemRepository createRepository() {
-    // Clean up the repo's content before giving it out
-    rmDir(new File(REPO_PATH));
     return newRepo(REPO_PATH);
   }
 
@@ -77,85 +75,6 @@ public class TestLocalFileSystemRepository extends AbstractTestRepository<LocalF
     newRepo(TEST_PATH + "/tmp/repo").close();
     newRepo(TEST_PATH + "/tmp/repo").close();
   }
-
-  @Test
-  public void testReadWritten() throws SchemaValidationException {
-    String path = TEST_PATH + "/readWrite";
-    LocalFileSystemRepository r = newRepo(path);
-    try {
-      r.register("sub1", null).register("sc1");
-      r.register("sub2", null).register("sc2");
-      r.register("sub2", null).register("sc3");
-    } finally {
-      r.close();
-    }
-    // Calling close() and newRepo() is like bouncing the repo, to ensure its state persists.
-    r = newRepo(path);
-    try {
-      Subject s1 = r.lookup("sub1");
-      Assert.assertNotNull(s1);
-      Subject s2 = r.lookup("sub2");
-      Assert.assertNotNull(s2);
-
-      SchemaEntry e1 = s1.lookupBySchema("sc1");
-      Assert.assertNotNull(e1);
-      Assert.assertEquals("sc1", e1.getSchema());
-
-      SchemaEntry e2 = s2.lookupBySchema("sc2");
-      Assert.assertNotNull(e2);
-      Assert.assertEquals("sc2", e2.getSchema());
-
-      SchemaEntry e3 = s2.lookupBySchema("sc3");
-      Assert.assertNotNull(e3);
-      Assert.assertEquals("sc3", e3.getSchema());
-    } finally {
-      r.close();
-    }
-  }
-
-  @Test
-  public void testReadWrittenMultiLineSchema() throws SchemaValidationException {
-    String path = TEST_PATH + "/readWriteMultiLine";
-
-    String endOfLine = System.getProperty("line.separator");
-
-    String multiLineSchema1 = "first line" + endOfLine + "second line";
-    String multiLineSchema2 = "first line" + endOfLine + "second line" + endOfLine;
-
-    LocalFileSystemRepository r = newRepo(path);
-    try {
-      r.register("sub1", null).register(multiLineSchema1);
-      r.register("sub1", null).register(multiLineSchema2);
-    } finally {
-      r.close();
-    }
-    // Calling close() and newRepo() is like bouncing the repo, to ensure its state persists.
-    r = newRepo(path);
-    try {
-      Subject s1 = r.lookup("sub1");
-      Assert.assertNotNull(s1);
-
-      SchemaEntry schemaEntry1ById = s1.lookupById("0");
-      Assert.assertNotNull(schemaEntry1ById);
-      Assert.assertEquals(multiLineSchema1, schemaEntry1ById.getSchema());
-
-      SchemaEntry schemaEntryBy1Schema = s1.lookupBySchema(multiLineSchema1);
-      Assert.assertNotNull(schemaEntryBy1Schema);
-      Assert.assertEquals(multiLineSchema1, schemaEntryBy1Schema.getSchema());
-
-      SchemaEntry schemaEntry2ById = s1.lookupById("1");
-      Assert.assertNotNull(schemaEntry2ById);
-      Assert.assertEquals(multiLineSchema1, schemaEntry2ById.getSchema());
-
-      SchemaEntry schemaEntry2BySchema = s1.lookupBySchema(multiLineSchema1);
-      Assert.assertNotNull(schemaEntry2BySchema);
-      Assert.assertEquals(multiLineSchema1, schemaEntry2BySchema.getSchema());
-
-    } finally {
-      r.close();
-    }
-  }
-
 
   @Test(expected = RuntimeException.class)
   public void testInvalidDir() throws IOException {

--- a/server/src/main/java/org/schemarepo/server/RESTRepository.java
+++ b/server/src/main/java/org/schemarepo/server/RESTRepository.java
@@ -122,7 +122,7 @@ public class RESTRepository {
   }
 
   /**
-   * Create a subejct if it does not already exist.
+   * Create a subject if it does not already exist.
    *
    * @param subject
    *          the name of the subject

--- a/server/src/main/java/org/schemarepo/server/RepositoryServer.java
+++ b/server/src/main/java/org/schemarepo/server/RepositoryServer.java
@@ -21,6 +21,7 @@ package org.schemarepo.server;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.Properties;
 
 import javax.inject.Named;
@@ -39,6 +40,9 @@ import com.google.inject.Provides;
 import com.google.inject.servlet.GuiceFilter;
 import com.sun.jersey.guice.JerseyServletModule;
 import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
+import org.eclipse.jetty.util.component.AbstractLifeCycle;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.schemarepo.Repository;
 import org.schemarepo.config.Config;
 import org.schemarepo.config.ConfigModule;
 
@@ -51,6 +55,7 @@ import org.schemarepo.config.ConfigModule;
  */
 public class RepositoryServer {
   private final Server server;
+  private final Injector injector;
 
   /**
    * Constructs an instance of this class, overlaying the default properties
@@ -66,7 +71,7 @@ public class RepositoryServer {
    *
    */
   public RepositoryServer(Properties props) {
-    Injector injector = Guice.createInjector(
+    this.injector = Guice.createInjector(
         new ConfigModule(props),
         new ServerModule());
     this.server = injector.getInstance(Server.class);
@@ -112,6 +117,38 @@ public class RepositoryServer {
     ConfigModule.printDefaults(System.err);
   }
 
+  /**
+   * Takes care of calling close() on the repo implementation.
+   *
+   * These hooks will not get called if stopAtShutdown is set to false, which can be set
+   * via the Config.JETTY_STOP_AT_SHUTDOWN property.
+   */
+  private static class ShutDownListener extends AbstractLifeCycle.AbstractLifeCycleListener {
+    private final Repository repo;
+    private final Integer gracefulShutdown;
+    ShutDownListener(Repository repo,
+                     Integer gracefulShutdown) {
+      this.repo = repo;
+      this.gracefulShutdown = gracefulShutdown;
+    }
+
+    @Override
+    public void lifeCycleStopping(LifeCycle event) {
+      System.out.println("Going to wait " + gracefulShutdown + " ms to drain requests" +
+              ", then close the repo and exit.");
+    }
+
+    @Override
+    public void lifeCycleStopped(LifeCycle event) {
+      System.out.println("Closing the repo.");
+      try {
+        repo.close();
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
   private static class ServerModule extends JerseyServletModule {
 
     @Override
@@ -129,6 +166,9 @@ public class RepositoryServer {
         @Named(Config.JETTY_PATH) String path,
         @Named(Config.JETTY_HEADER_SIZE) Integer headerSize,
         @Named(Config.JETTY_BUFFER_SIZE) Integer bufferSize,
+        @Named(Config.JETTY_STOP_AT_SHUTDOWN) Boolean stopAtShutdown,
+        @Named(Config.JETTY_GRACEFUL_SHUTDOWN) Integer gracefulShutdown,
+        Repository repo,
         Connector connector,
         GuiceFilter guiceFilter,
         ServletContextHandler handler) {
@@ -148,8 +188,11 @@ public class RepositoryServer {
       handler.addFilter(holder, "/*", null);
       handler.addServlet(NoneServlet.class, "/");
       handler.setContextPath(path);
+      handler.addLifeCycleListener(new ShutDownListener(repo, gracefulShutdown));
       server.setHandler(handler);
       server.dumpStdErr();
+      server.setStopAtShutdown(stopAtShutdown);
+      server.setGracefulShutdown(gracefulShutdown);
       return server;
     }
 

--- a/server/src/test/java/org/schemarepo/server/TestRepo.java
+++ b/server/src/test/java/org/schemarepo/server/TestRepo.java
@@ -29,7 +29,8 @@ public class TestRepo {
   public void testRepoInit() throws Exception {
     Properties props = new Properties();
     props.setProperty("schema-repo.class", InMemoryRepository.class.getName());
-    props.setProperty("jetty.port", "6782");
+    props.setProperty("schema-repo.jetty.port", "6782");
+    props.setProperty("schema-repo.jetty.graceful-shutdown", "10"); // Shutdown quickly for tests
 
     RepositoryServer server = new RepositoryServer(props);
 


### PR DESCRIPTION
- Made Repository implement Closeable and changed all Repository implementations accordingly.
- Moved the LocalFileSystem's tests to a new AbstractTestPersistentRepository class, which LocalFS and ZK tests extend.
- Actually found a bug in the previous implementation of the multi-line test and LocalFS repo, and fixed those bugs.
- Enabled (and added config for) the Jetty capability to hook into the shutdown event, to make sure repos are always closed.
