### PR TITLE
Issue #9: Strongly-typed API.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -27,28 +27,13 @@
     <relativePath>../</relativePath>
   </parent>
 
-  <artifactId>schema-repo-zookeeper</artifactId>
+  <artifactId>schema-repo-api</artifactId>
 
-  <name>Schema Repository ZK Backend</name>
+  <name>Schema Repository API</name>
   <url>http://schemarepo.org</url>
-  <description>Schema Repository backed and synchronized by a Zookeeper ensemble</description>
+  <description>Schema Repository Strongly-Typed API</description>
 
   <build>
-  <!-- additionally create a test-jar artifact -->
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
   </build>
 
   <profiles>
@@ -62,31 +47,13 @@
     </dependency>
     <dependency>
       <groupId>org.schemarepo</groupId>
-      <artifactId>schema-repo-common</artifactId>
+      <artifactId>schema-repo-avro</artifactId>
       <version>${project.version}</version>
-      <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.schemarepo</groupId>
-      <artifactId>schema-repo-server</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.curator</groupId>
-      <artifactId>curator-recipes</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.curator</groupId>
-      <artifactId>curator-test</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
-      <version>1</version>
-      <!-- users who choose to use the annotations for Guice/Spring/etc
-       will need to include this, others can ignore -->
-      <optional>true</optional>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
     </dependency>
   </dependencies>
 

--- a/api/src/main/java/org/schemarepo/api/TypedSchemaRepository.java
+++ b/api/src/main/java/org/schemarepo/api/TypedSchemaRepository.java
@@ -1,0 +1,320 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.schemarepo.api;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.Lists;
+import org.schemarepo.Repository;
+import org.schemarepo.SchemaEntry;
+import org.schemarepo.SchemaValidationException;
+import org.schemarepo.Subject;
+import org.schemarepo.SubjectConfig;
+import org.schemarepo.api.converter.Converter;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This is a convenience class for interacting with a Schema Repository in an
+ * efficient manner. It is (lazily) cached whenever possible and strongly-typed.
+ *
+ * N.B.: Currently, there is no cache eviction mechanism, so this can
+ * potentially grow to unbounded sizes.
+ *
+ * N.B.2: registerIfLatest() is not supported in the TypedSchemaRepository,
+ * at least for now...
+ */
+public class TypedSchemaRepository<REPO extends Repository, ID, SCHEMA, SUBJECT> {
+
+  private REPO repo;
+  private Converter<ID> convertId;
+  private Converter<SCHEMA> convertSchema;
+  private Converter<SUBJECT> convertSubject;
+  private SubjectConfig.Builder defaultSubjectConfigBuilder;
+
+  // Internal state
+
+  private Map<SUBJECT, BiMap<ID, SCHEMA>> subjectToIdToSchemaCache;
+
+  // Constructors
+
+  public TypedSchemaRepository(
+          REPO repo,
+          Converter<ID> idConverter,
+          Converter<SCHEMA> schemaConverter,
+          Converter<SUBJECT> subjectConverter,
+          SubjectConfig.Builder defaultSubjectConfigBuilder) {
+    this.repo = repo;
+    this.convertId = idConverter;
+    this.convertSchema = schemaConverter;
+    this.convertSubject = subjectConverter;
+    this.defaultSubjectConfigBuilder = defaultSubjectConfigBuilder;
+    this.subjectToIdToSchemaCache = new HashMap<SUBJECT, BiMap<ID, SCHEMA>>();
+  }
+
+  public TypedSchemaRepository(
+          REPO repo,
+          Converter<ID> idConverter,
+          Converter<SCHEMA> schemaConverter,
+          Converter<SUBJECT> subjectConverter) {
+    this(repo, idConverter, schemaConverter, subjectConverter,
+            new SubjectConfig.Builder());
+  }
+
+  /**
+   * Utility function for getting a idToSchemaCache for a given subject, or
+   * initializing such cache if it does not exist yet.
+   *
+   * @param subjectName of the desired idToSchemaCache
+   * @return the idToSchemaCache for the requested subject
+   */
+  private BiMap<ID, SCHEMA> getIdToSchemaCache(SUBJECT subjectName) {
+    BiMap<ID, SCHEMA> idToSchemaCache = subjectToIdToSchemaCache.get(subjectName);
+    if (idToSchemaCache == null) {
+      synchronized (this) {
+        // Checking again, in case it was initialized between the initial get
+        // and the if check.
+        idToSchemaCache = subjectToIdToSchemaCache.get(subjectName);
+        if (idToSchemaCache == null) {
+          idToSchemaCache = HashBiMap.create();
+          subjectToIdToSchemaCache.put(subjectName, idToSchemaCache);
+        }
+      }
+    }
+    return idToSchemaCache;
+  }
+
+  /**
+   * Utility function for getting a schemaToIdCache for a given subject, or
+   * initializing such cache if it does not exist yet.
+   *
+   * @param subjectName of the desired schemaToIdCache
+   * @return the schemaToIdCache for the requested subject
+   */
+  private BiMap<SCHEMA, ID> getSchemaToIdCache(SUBJECT subjectName){
+    return getIdToSchemaCache(subjectName).inverse(); // Ensures initialization
+  }
+
+  // PUBLIC APIs BELOW
+
+  /**
+   * Gets a schema for a given subject and ID.
+   *
+   * This retrieves immutable data, hence it is cache-able indefinitely.
+   *
+   * @param subjectName containing the sought schema
+   * @param id of the sought schema
+   * @return the sought schema, or null if the subject does not exist or if it
+   *         does not have any registered schemas yet.
+   */
+  public SCHEMA getSchema(SUBJECT subjectName, ID id) {
+    SCHEMA schema = null;
+
+    /**
+     * Implementation detail: We first peek directly in the cache without going
+     * through {@link #getIdToSchemaCache(Object)} because we don't want to
+     * bloat the cache with an empty map if the subject or ID does not exist
+     * in the remote repository.
+     */
+    Map<ID, SCHEMA> idToSchemaCache = subjectToIdToSchemaCache.get(subjectName);
+    if (idToSchemaCache != null) {
+      schema = idToSchemaCache.get(id);
+    }
+
+    if (schema == null) {
+      Subject subject = repo.lookup(convertSubject.toString(subjectName));
+      if (subject != null) {
+        SchemaEntry schemaEntry = subject.lookupById(convertId.toString(id));
+        if (schemaEntry != null) {
+          schema = convertSchema.fromString(schemaEntry.getSchema());
+          getIdToSchemaCache(subjectName).put(id, schema); // idempotent
+        }
+      }
+    }
+
+    return schema;
+  }
+
+  /**
+   * Gets the latest schema for a given subject.
+   *
+   * This retrieves mutable data, hence it is not cache-able and will always
+   * result in a call to the underlying schema repo implementation.
+   *
+   * @param subjectName to get the latest schema for
+   * @return the latest schema for the requested subject, or null if the subject
+   *         does not exist or if it contains no schemas yet.
+   */
+  public SCHEMA getLatestSchema(SUBJECT subjectName) {
+    SCHEMA schema = null;
+
+    Subject subject = repo.lookup(convertSubject.toString(subjectName));
+    if (subject != null) {
+      SchemaEntry schemaEntry = subject.latest();
+      if (schemaEntry != null) {
+        Map<ID, SCHEMA> idToSchemaCache = getIdToSchemaCache(subjectName);
+        ID id = convertId.fromString(schemaEntry.getId());
+        /**
+         * Implementation detail: First, we check if the latest ID is already in
+         * cache, to avoid the cost of converting the String literal schema to
+         * its strong type if we already have it in-memory.
+         */
+        schema = idToSchemaCache.get(id);
+        if (schema == null) {
+          schema = convertSchema.fromString(schemaEntry.getSchema());
+          idToSchemaCache.put(id, schema); // idempotent
+        }
+      }
+    }
+
+    return schema;
+  }
+
+  /**
+   * Gets a schema ID for a given subject and schema.
+   *
+   * This retrieves immutable data, hence it is cache-able indefinitely.
+   *
+   * @param subjectName containing the sought ID
+   * @param schema corresponding to the sought ID
+   * @return the sought ID, or null if the subject does not exist or if it
+   *         does not have any registered schemas yet.
+   */
+  public ID getSchemaId(SUBJECT subjectName, SCHEMA schema) {
+    ID id = null;
+
+    /**
+     * Implementation detail: We first peek directly in the cache without going
+     * through {@link #getSchemaToIdCache(Object)} because we don't want to
+     * bloat the cache with an empty map if the subject or schema does not exist
+     * in the remote repository.
+     */
+    BiMap<ID, SCHEMA> idToSchemaCache = subjectToIdToSchemaCache.get(subjectName);
+    if (idToSchemaCache != null) {
+      id = idToSchemaCache.inverse().get(schema);
+    }
+
+    if (id == null) {
+      Subject subject = repo.lookup(convertSubject.toString(subjectName));
+      if (subject != null) {
+        SchemaEntry schemaEntry = subject.lookupBySchema(convertSchema.toString(schema));
+        if (schemaEntry != null) {
+          id = convertId.fromString(schemaEntry.getId());
+          getSchemaToIdCache(subjectName).put(schema, id); // idempotent
+        }
+      }
+    }
+
+    return id;
+  }
+
+  /**
+   * Registers a new schema in the given subject and returns its ID. If the
+   * schema already existed, its previous ID will be returned instead.
+   *
+   * This will only result in a call to the underlying schema repo
+   * implementation if the schema is not already known in the local cache.
+   *
+   * N.B.: If the subject does not exist yet, it will be initialized with a
+   * config built from the defaultSubjectConfigBuilder provided to the
+   * {@link TypedSchemaRepository} at construction time. If you wish to use a
+   * non-default configuration, you should first invoke
+   * {@link #setConfig(Object, org.schemarepo.SubjectConfig)} before invoking
+   * this function.
+   *
+   * @param subjectName to register the schema into
+   * @param schema to register
+   * @return the ID of the registered schema
+   * @throws SchemaValidationException
+   */
+  public ID registerSchema(SUBJECT subjectName,
+                           SCHEMA schema)
+          throws SchemaValidationException {
+    Map<SCHEMA, ID> schemaToIdCache = getSchemaToIdCache(subjectName);
+    ID id = schemaToIdCache.get(schema);
+
+    if (id == null) {
+      Subject subject = repo.lookup(convertSubject.toString(subjectName));
+      if (subject == null) {
+        subject = repo.register(convertSubject.toString(subjectName),
+                defaultSubjectConfigBuilder.build());
+      }
+      /**
+       * Implementation detail: The repo is expected to act as a synchronized,
+       * consistent authority. Therefore, even if there is a race condition
+       * where two calls to {@link #registerSchema(Object, Object)} happen
+       * simultaneously (whether with identical or with different schemas),
+       * the repo should correctly register each schema once with a unique ID.
+       * Therefore, the schemaToIdCache.put operation can be considered
+       * idempotent because it is immutable data which is going into the cache.
+       */
+      SchemaEntry schemaEntry = subject.register(convertSchema.toString(schema));
+      id = convertId.fromString(schemaEntry.getId());
+      schemaToIdCache.put(schema, id); // idempotent
+    }
+
+    return id;
+  }
+
+  /**
+   * This retrieves mutable data, hence it is not cache-able and will always
+   * result in a call to the underlying schema repo implementation.
+   *
+   * @param subjectName to get the config for
+   * @return the requested subject's config, or null if the subject does not exist
+   */
+  public SubjectConfig getConfig(SUBJECT subjectName) {
+    Subject subject = repo.lookup(convertSubject.toString(subjectName));
+    if (subject != null) {
+      return subject.getConfig();
+    } else {
+      return null; // or throw exception?
+    }
+  }
+
+  /**
+   * This sets mutable data, hence it will always result in a call to the
+   * underlying schema repo implementation.
+   *
+   * If the subject does not exist, it will be initialized with the given
+   * config, but will not contain any ID/schema pair.
+   *
+   * @param subjectName to change the config for
+   * @param subjectConfig to set for the given subject
+   */
+  public void setConfig(SUBJECT subjectName, SubjectConfig subjectConfig) {
+    repo.register(convertSubject.toString(subjectName), subjectConfig);
+  }
+
+  /**
+   * This retrieves mutable data, hence it is not cache-able and will always
+   * result in a call to the underlying schema repo implementation.
+   *
+   * @return the list of all Subjects currently registered
+   */
+  public List<SUBJECT> getSubjects() {
+    List<SUBJECT> subjects = Lists.newArrayList();
+    for (Subject subject: repo.subjects()) {
+      subjects.add(convertSubject.fromString(subject.getName()));
+    }
+    return subjects;
+  }
+}

--- a/api/src/main/java/org/schemarepo/api/converter/ByteConverter.java
+++ b/api/src/main/java/org/schemarepo/api/converter/ByteConverter.java
@@ -16,20 +16,24 @@
  * permissions and limitations under the License.
  */
 
-package org.schemarepo;
+package org.schemarepo.api.converter;
 
 /**
- * Static Strings used to communicate a message to the end-user.
+ * To convert back and forth with Byte.
+ *
+ * For most people this can be a reasonable choice for IDs. Most use cases
+ * should require less than 256 schemas per subject. However, if one wants to be
+ * extra paranoid about future extensibility, the ShortConverter should provide
+ * as much mileage as one might need.
  */
-public class MessageStrings {
-  public static final String SCHEMA_WITH_NEWLINE_ERROR =
-          "ERROR: One of the schemas for this " +
-          "topic contains a new line and won't be parse-able properly. " +
-          "Please use a non-plain text format instead (e.g.: JSON).\n";
+public class ByteConverter implements Converter<Byte> {
+  @Override
+  public Byte fromString(String literal) {
+    return Byte.parseByte(literal);
+  }
 
-  public static final String SUBJECT_DOES_NOT_EXIST_ERROR =
-          "ERROR: This subject does not exist.\n";
-
-  public static final String SCHEMA_DOES_NOT_EXIST_ERROR =
-          "ERROR: This schema does not exist.\n";
+  @Override
+  public String toString(Byte strongType) {
+    return strongType.toString();
+  }
 }

--- a/api/src/main/java/org/schemarepo/api/converter/EnumConverter.java
+++ b/api/src/main/java/org/schemarepo/api/converter/EnumConverter.java
@@ -16,20 +16,31 @@
  * permissions and limitations under the License.
  */
 
-package org.schemarepo;
+package org.schemarepo.api.converter;
 
 /**
- * Static Strings used to communicate a message to the end-user.
+ * This converter can be useful for people who wish to constrain the usable
+ * subjects to a predetermined set of elements, i.e.: an Enum.
  */
-public class MessageStrings {
-  public static final String SCHEMA_WITH_NEWLINE_ERROR =
-          "ERROR: One of the schemas for this " +
-          "topic contains a new line and won't be parse-able properly. " +
-          "Please use a non-plain text format instead (e.g.: JSON).\n";
+public class EnumConverter<E extends Enum<E>> implements Converter<E> {
 
-  public static final String SUBJECT_DOES_NOT_EXIST_ERROR =
-          "ERROR: This subject does not exist.\n";
+  private Class<E> enumClass;
 
-  public static final String SCHEMA_DOES_NOT_EXIST_ERROR =
-          "ERROR: This schema does not exist.\n";
+  public EnumConverter(E enumInstance) {
+    this.enumClass = enumInstance.getDeclaringClass();
+  }
+
+  public EnumConverter(Class<E> enumClass) {
+    this.enumClass = enumClass;
+  }
+
+  @Override
+  public E fromString(String literal) {
+    return Enum.valueOf(enumClass, literal);
+  }
+
+  @Override
+  public String toString(E strongType) {
+    return strongType.name();
+  }
 }

--- a/api/src/main/java/org/schemarepo/api/converter/IdentityConverter.java
+++ b/api/src/main/java/org/schemarepo/api/converter/IdentityConverter.java
@@ -16,20 +16,19 @@
  * permissions and limitations under the License.
  */
 
-package org.schemarepo;
+package org.schemarepo.api.converter;
 
 /**
- * Static Strings used to communicate a message to the end-user.
+ * For the entities you wish to use directly as Strings, without any conversion.
  */
-public class MessageStrings {
-  public static final String SCHEMA_WITH_NEWLINE_ERROR =
-          "ERROR: One of the schemas for this " +
-          "topic contains a new line and won't be parse-able properly. " +
-          "Please use a non-plain text format instead (e.g.: JSON).\n";
+public class IdentityConverter implements Converter<String> {
+  @Override
+  public String fromString(String literal) {
+    return literal;
+  }
 
-  public static final String SUBJECT_DOES_NOT_EXIST_ERROR =
-          "ERROR: This subject does not exist.\n";
-
-  public static final String SCHEMA_DOES_NOT_EXIST_ERROR =
-          "ERROR: This schema does not exist.\n";
+  @Override
+  public String toString(String strongType) {
+    return strongType;
+  }
 }

--- a/api/src/main/java/org/schemarepo/api/converter/IntegerConverter.java
+++ b/api/src/main/java/org/schemarepo/api/converter/IntegerConverter.java
@@ -16,20 +16,25 @@
  * permissions and limitations under the License.
  */
 
-package org.schemarepo;
+package org.schemarepo.api.converter;
 
 /**
- * Static Strings used to communicate a message to the end-user.
+ * To convert back and forth with Integer.
+ *
+ * As a converter for IDs, this is probably overkill for most use cases, since
+ * it allows billions of schemas per subject. There may be some highly generic
+ * and dynamic system architectures that would warrant such high cardinality,
+ * but for most intents and purposes, one should probably think twice about
+ * using this kind of ID.
  */
-public class MessageStrings {
-  public static final String SCHEMA_WITH_NEWLINE_ERROR =
-          "ERROR: One of the schemas for this " +
-          "topic contains a new line and won't be parse-able properly. " +
-          "Please use a non-plain text format instead (e.g.: JSON).\n";
+public class IntegerConverter implements Converter<Integer> {
+  @Override
+  public Integer fromString(String literal) {
+    return Integer.parseInt(literal);
+  }
 
-  public static final String SUBJECT_DOES_NOT_EXIST_ERROR =
-          "ERROR: This subject does not exist.\n";
-
-  public static final String SCHEMA_DOES_NOT_EXIST_ERROR =
-          "ERROR: This schema does not exist.\n";
+  @Override
+  public String toString(Integer strongType) {
+    return strongType.toString();
+  }
 }

--- a/api/src/main/java/org/schemarepo/api/converter/ShortConverter.java
+++ b/api/src/main/java/org/schemarepo/api/converter/ShortConverter.java
@@ -16,20 +16,23 @@
  * permissions and limitations under the License.
  */
 
-package org.schemarepo;
+package org.schemarepo.api.converter;
 
 /**
- * Static Strings used to communicate a message to the end-user.
+ * To convert back and forth with Short.
+ *
+ * For most people this can be a reasonable choice for IDs. If anyone needs to
+ * store more than 65K schemas for a single subject, they should probably take
+ * a long hard look at how they're using the schema repo.
  */
-public class MessageStrings {
-  public static final String SCHEMA_WITH_NEWLINE_ERROR =
-          "ERROR: One of the schemas for this " +
-          "topic contains a new line and won't be parse-able properly. " +
-          "Please use a non-plain text format instead (e.g.: JSON).\n";
+public class ShortConverter implements Converter<Short> {
+  @Override
+  public Short fromString(String literal) {
+    return Short.parseShort(literal);
+  }
 
-  public static final String SUBJECT_DOES_NOT_EXIST_ERROR =
-          "ERROR: This subject does not exist.\n";
-
-  public static final String SCHEMA_DOES_NOT_EXIST_ERROR =
-          "ERROR: This schema does not exist.\n";
+  @Override
+  public String toString(Short strongType) {
+    return strongType.toString();
+  }
 }

--- a/api/src/test/java/org/schemarepo/api/TestTypedSchemaRepository.java
+++ b/api/src/test/java/org/schemarepo/api/TestTypedSchemaRepository.java
@@ -1,0 +1,193 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.schemarepo.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.schemarepo.InMemoryRepository;
+import org.schemarepo.Repository;
+import org.schemarepo.SchemaValidationException;
+import org.schemarepo.ValidatorFactory;
+import org.schemarepo.api.converter.AvroSchemaConverter;
+import org.schemarepo.api.converter.ByteConverter;
+import org.schemarepo.api.converter.Converter;
+import org.schemarepo.api.converter.EnumConverter;
+import org.schemarepo.api.converter.IdentityConverter;
+import org.schemarepo.api.converter.IntegerConverter;
+import org.schemarepo.api.converter.ShortConverter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests for the TypedSchemaRepository for ALL combinations of registered
+ * repository implementations, ID, schema and subject types.
+ */
+public class TestTypedSchemaRepository {
+
+  /**
+   * This provider interface is necessary in order to recreate repository
+   * instances for each test. Otherwise, their state could carry over across
+   * tests.
+   */
+  public interface RepositoryProvider {
+    public Repository createRepository();
+  }
+
+  private enum EnumSubjectExample {
+    sub1, sub2;
+  }
+
+  @Test
+  public void testRepoCombinations(){
+    List<RepositoryProvider> repositoryProviders = new ArrayList<RepositoryProvider>();
+    List<Converter> idConverters = new ArrayList<Converter>();
+    List<Converter> schemaConverters = new ArrayList<Converter>();
+    List<Converter> subjectConverters = new ArrayList<Converter>();
+
+    // Tested repositories
+    repositoryProviders.add(new RepositoryProvider() {
+      @Override
+      public Repository createRepository() {
+        return new InMemoryRepository(new ValidatorFactory.Builder().build());
+      }
+    });
+
+    // TODO: Decide if we actually want to test other repo implementations here
+
+    // Tested ID Converters
+    idConverters.add(new IdentityConverter());
+    idConverters.add(new ByteConverter());
+    idConverters.add(new ShortConverter());
+    idConverters.add(new IntegerConverter());
+
+    // Tested Schema Converters
+    schemaConverters.add(new IdentityConverter());
+    schemaConverters.add(new AvroSchemaConverter(true));
+    schemaConverters.add(new AvroSchemaConverter(false));
+
+    // Tested Subject Converters
+    subjectConverters.add(new IdentityConverter());
+    subjectConverters.add(new EnumConverter(EnumSubjectExample.sub2));
+
+    for (RepositoryProvider repoProvider: repositoryProviders) {
+      for (Converter idConverter: idConverters) {
+        for (Converter schemaConverter: schemaConverters) {
+          for (Converter subjectConverter: subjectConverters) {
+            testRegistration(repoProvider.createRepository(),
+                    idConverter, schemaConverter, subjectConverter);
+
+            // TODO: Add more tests
+          }
+        }
+      }
+    }
+  }
+
+  private <INNER_REPO extends Repository, ID, SCHEMA, SUBJECT> void testRegistration(
+          INNER_REPO innerRepo,
+          Converter<ID> convertId,
+          Converter<SCHEMA> convertSchema,
+          Converter<SUBJECT> convertSubject) {
+
+    String testName = "TypedSchemaRepository(" +
+            innerRepo.getClass().getSimpleName() + ", " +
+            convertId.getClass().getSimpleName() + ", " +
+            convertSchema.getClass().getSimpleName() + ", " +
+            convertSubject.getClass().getSimpleName() + "): ";
+
+    try {
+      TypedSchemaRepository<INNER_REPO, ID, SCHEMA, SUBJECT> repo =
+              new TypedSchemaRepository<INNER_REPO, ID, SCHEMA, SUBJECT>
+                      (innerRepo, convertId, convertSchema, convertSubject);
+
+      SUBJECT subject1 = convertSubject.fromString("sub1");
+
+      // TODO: Decouple Avro schema literals when we want to support other serialization
+      SCHEMA subject1Schema1 = convertSchema.fromString("{\"type\":\"record\"," +
+              "\"name\":\"subject1\",\"fields\":" +
+              "[{\"name\":\"someId\",\"type\":\"long\"}," +
+              "{\"name\":\"someString\",\"type\":[\"null\",\"string\"]}]}");
+      SCHEMA subject1Schema2 = convertSchema.fromString("{\"type\":\"record\"," +
+              "\"name\":\"subject1\",\"fields\":" +
+              "[{\"name\":\"someId\",\"type\":\"long\"}," +
+              "{\"name\":\"someString\",\"type\":[\"null\",\"string\"]}," +
+              "{\"name\":\"someNewId\",\"type\":[\"null\",\"int\"]}]}");
+
+      SCHEMA latestSchemaForSubject1 = repo.getLatestSchema(subject1);
+      Assert.assertNull(testName + "Latest schema should be null before being registered.",
+              latestSchemaForSubject1);
+
+      // register 1st schema
+      ID idForSubject1Schema1 = repo.registerSchema(subject1, subject1Schema1);
+
+      // getLatestSchema
+      latestSchemaForSubject1 = repo.getLatestSchema(subject1);
+      Assert.assertEquals(testName + "getLatestSchema should be what we just registered.",
+              subject1Schema1, latestSchemaForSubject1);
+
+      // getSchema
+      SCHEMA schema1ForSubject1ById = repo.getSchema(subject1, idForSubject1Schema1);
+      Assert.assertEquals(testName + "getSchema by ID should be what we just registered.",
+              subject1Schema1, schema1ForSubject1ById);
+
+      // register 2nd schema
+      ID idForSubject1Schema2 = repo.registerSchema(subject1, subject1Schema2);
+
+      // getLatestSchema
+      latestSchemaForSubject1 = repo.getLatestSchema(subject1);
+      Assert.assertNotEquals(testName + "getLatestSchema should not still be the old schema.",
+              subject1Schema1, latestSchemaForSubject1);
+      Assert.assertEquals(testName + "getLatestSchema should be what we just registered.",
+              subject1Schema2, latestSchemaForSubject1);
+
+      // getSchema
+      schema1ForSubject1ById = repo.getSchema(subject1, idForSubject1Schema1);
+      Assert.assertEquals(testName + "getSchema for 1st ID should work.",
+              subject1Schema1, schema1ForSubject1ById);
+
+      SCHEMA schema2ForSubject1ById = repo.getSchema(subject1, idForSubject1Schema2);
+      Assert.assertEquals(testName + "getSchema for 2nd ID should work.",
+              subject1Schema2, schema2ForSubject1ById);
+
+      // getSchemaId
+      ID idForSubject1Schema1BySchema = repo.getSchemaId(subject1, subject1Schema1);
+      ID idForSubject1Schema2BySchema = repo.getSchemaId(subject1, subject1Schema2);
+      Assert.assertEquals(testName + "getSchemaId should return the same ID as during registration",
+              idForSubject1Schema1, idForSubject1Schema1BySchema);
+      Assert.assertEquals(testName + "getSchemaId should return the same ID as during registration",
+              idForSubject1Schema2, idForSubject1Schema2BySchema);
+      Assert.assertNotEquals(testName + "getSchemaId should not always return the same ID",
+              idForSubject1Schema1BySchema, idForSubject1Schema2BySchema);
+
+      // TODO: Add more registration-related test cases.
+
+    } catch (SchemaValidationException e) {
+      Assert.fail(testName + "A SchemaValidationException was thrown during testRegistration: " +
+              e.getMessage());
+    } finally {
+      try {
+        innerRepo.close();
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+}

--- a/avro/pom.xml
+++ b/avro/pom.xml
@@ -27,28 +27,13 @@
     <relativePath>../</relativePath>
   </parent>
 
-  <artifactId>schema-repo-zookeeper</artifactId>
+  <artifactId>schema-repo-avro</artifactId>
 
-  <name>Schema Repository ZK Backend</name>
+  <name>Schema Repository Avro Integration</name>
   <url>http://schemarepo.org</url>
-  <description>Schema Repository backed and synchronized by a Zookeeper ensemble</description>
+  <description>Schema Repository Avro Integration</description>
 
   <build>
-  <!-- additionally create a test-jar artifact -->
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
   </build>
 
   <profiles>
@@ -61,32 +46,9 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.schemarepo</groupId>
-      <artifactId>schema-repo-common</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.schemarepo</groupId>
-      <artifactId>schema-repo-server</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.curator</groupId>
-      <artifactId>curator-recipes</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.curator</groupId>
-      <artifactId>curator-test</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
-      <version>1</version>
-      <!-- users who choose to use the annotations for Guice/Spring/etc
-       will need to include this, others can ignore -->
-      <optional>true</optional>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>${avro.version}</version>
     </dependency>
   </dependencies>
 

--- a/avro/src/main/java/org/schemarepo/api/converter/AvroSchemaConverter.java
+++ b/avro/src/main/java/org/schemarepo/api/converter/AvroSchemaConverter.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.schemarepo.api.converter;
+
+import org.apache.avro.Schema;
+
+/**
+ * This converter can be used for handling Avro schemas.
+ */
+public class AvroSchemaConverter implements Converter<Schema> {
+
+  private final Boolean prettyPrint;
+
+  public AvroSchemaConverter() {
+    this(true);
+  }
+
+  public AvroSchemaConverter(Boolean prettyPrint) {
+    this.prettyPrint = prettyPrint;
+  }
+
+  /**
+   * Given a String literal, provide a strongly-typed instance.
+   *
+   * @param literal to be converted
+   * @return the requested TYPE
+   */
+  @Override
+  @SuppressWarnings("deprecation")
+  public Schema fromString(String literal) {
+    // Non-deprecated code for Avro 1.7.x :
+    // return new Schema.Parser().parse(literal);
+
+    // N.B.: Willfully using the deprecated Avro API to maintain
+    // compatibility with older Avro jars.
+    return Schema.parse(literal);
+  }
+
+  /**
+   * Given a strongly-typed instance, provide its String literal representation.
+   *
+   * @param strongType instance to be converted
+   * @return the String literal representation
+   */
+  @Override
+  public String toString(Schema strongType) {
+    return strongType.toString(prettyPrint);
+  }
+}

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -29,9 +29,9 @@
 
   <artifactId>schema-repo-client</artifactId>
 
-  <name>Schema Repository Client</name>
+  <name>Schema Repository REST Client</name>
   <url>http://schemarepo.org</url>
-  <description>Schema Repository Client</description>
+  <description>Schema Repository REST Client</description>
 
   <build>
   </build>
@@ -48,7 +48,6 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/client/src/test/java/org/schemarepo/client/AbstractTestRepositoryClient.java
+++ b/client/src/test/java/org/schemarepo/client/AbstractTestRepositoryClient.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.schemarepo.client;
+
+import java.util.Properties;
+
+import org.schemarepo.AbstractTestRepository;
+import org.schemarepo.InMemoryRepository;
+import org.schemarepo.config.Config;
+import org.schemarepo.server.RepositoryServer;
+
+public abstract class AbstractTestRepositoryClient<R extends RepositoryClient> extends AbstractTestRepository<R> {
+
+  protected RepositoryServer server;
+
+  @Override
+  protected R createRepository() throws Exception {
+    Properties props = new Properties();
+    props.put(Config.REPO_CLASS, InMemoryRepository.class.getName());
+    props.put(Config.JETTY_HOST, "localhost");
+    props.put(Config.JETTY_PORT, "8123");
+    props.put(Config.JETTY_GRACEFUL_SHUTDOWN, "100");
+    server = new RepositoryServer(props);
+    server.start();
+    return createClient("http://localhost:8123/schema-repo/");
+  }
+
+  protected abstract R createClient(String repoUrl);
+
+  @Override
+  public void tearDownRepository() throws Exception {
+    server.stop();
+    super.tearDownRepository();
+  }
+
+}

--- a/common/src/main/java/org/schemarepo/api/converter/Converter.java
+++ b/common/src/main/java/org/schemarepo/api/converter/Converter.java
@@ -16,20 +16,26 @@
  * permissions and limitations under the License.
  */
 
-package org.schemarepo;
+package org.schemarepo.api.converter;
 
 /**
- * Static Strings used to communicate a message to the end-user.
+ * An interface which the TypedSchemaRepository uses to convert IDs, schema
+ * literals and subject names back and forth with Strings.
  */
-public class MessageStrings {
-  public static final String SCHEMA_WITH_NEWLINE_ERROR =
-          "ERROR: One of the schemas for this " +
-          "topic contains a new line and won't be parse-able properly. " +
-          "Please use a non-plain text format instead (e.g.: JSON).\n";
+public interface Converter<TYPE> {
+  /**
+   * Given a String literal, provide a strongly-typed instance.
+   *
+   * @param literal to be converted
+   * @return the requested TYPE
+   */
+  TYPE fromString(String literal);
 
-  public static final String SUBJECT_DOES_NOT_EXIST_ERROR =
-          "ERROR: This subject does not exist.\n";
-
-  public static final String SCHEMA_DOES_NOT_EXIST_ERROR =
-          "ERROR: This schema does not exist.\n";
+  /**
+   * Given a strongly-typed instance, provide its String literal representation.
+   *
+   * @param strongType instance to be converted
+   * @return the String literal representation
+   */
+  String toString(TYPE strongType);
 }

--- a/common/src/main/java/org/schemarepo/json/GsonJsonUtil.java
+++ b/common/src/main/java/org/schemarepo/json/GsonJsonUtil.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package org.schemarepo.json;
 
 import com.google.gson.ExclusionStrategy;

--- a/common/src/main/java/org/schemarepo/json/JsonUtil.java
+++ b/common/src/main/java/org/schemarepo/json/JsonUtil.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package org.schemarepo.json;
 
 import org.schemarepo.SchemaEntry;

--- a/common/src/test/java/org/schemarepo/AbstractTestPersistentRepository.java
+++ b/common/src/test/java/org/schemarepo/AbstractTestPersistentRepository.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package org.schemarepo;
 
 import org.junit.Assert;

--- a/common/src/test/java/org/schemarepo/json/TestGsonJsonUtil.java
+++ b/common/src/test/java/org/schemarepo/json/TestGsonJsonUtil.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package org.schemarepo.json;
 
 /**

--- a/common/src/test/java/org/schemarepo/json/TestJsonUtil.java
+++ b/common/src/test/java/org/schemarepo/json/TestJsonUtil.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package org.schemarepo.json;
 
 import org.junit.Assert;

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,8 @@
 
   <modules>
     <module>common</module>
+    <module>api</module>
+    <module>avro</module>
     <module>server</module>
     <module>client</module>
     <module>bundle</module>
@@ -93,6 +95,8 @@
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.1.2</logback.version>
     <gson.version>2.3.1</gson.version>
+    <guava.version>18.0</guava.version>
+    <avro.version>1.7.7</avro.version>
 
     <!-- version properties for plugins -->
     <enforcer-plugin.version>1.3.1</enforcer-plugin.version>
@@ -143,6 +147,16 @@
         <groupId>com.sun.jersey</groupId>
         <artifactId>jersey-server</artifactId>
         <version>${jersey.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.jersey</groupId>
+        <artifactId>jersey-client</artifactId>
+        <version>${jersey.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${guava.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.curator</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -29,7 +29,7 @@
 
   <artifactId>schema-repo-server</artifactId>
 
-  <name>Schema Repository Server</name>
+  <name>Schema Repository REST Server</name>
   <url>http://schemarepo.org</url>
   <description>Schema Repository REST server components</description>
 

--- a/server/src/main/java/org/schemarepo/config/ConfigModule.java
+++ b/server/src/main/java/org/schemarepo/config/ConfigModule.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package org.schemarepo.config;
 
 import java.io.PrintStream;

--- a/zk-bundle/pom.xml
+++ b/zk-bundle/pom.xml
@@ -29,7 +29,7 @@
 
   <artifactId>schema-repo-zk-bundle</artifactId>
 
-  <name>Schema Repository on ZK Bundle</name>
+  <name>Schema Repository ZK Backend Bundle</name>
   <url>http://schemarepo.org</url>
   <description>Schema Repository standalone ZK bundle</description>
 


### PR DESCRIPTION
Squashed all changes into one commit and rebased on the current master so it applies more cleanly.

Original description from PR #23 :

--

Hi,

This is a proposal for enriching the user experience of interacting with a schema repository.

A new module, schema-repo-api, is introduced which provides a TypedSchemaRepository class and some common Converters that can be used with it. The TypedSchemaRepository is generically typed so that users can reliably and efficiently deal with the types they're interested in rather than Strings.

The API is also simpler than the current Repository/Subject class composition. Users can get whatever they want directly and in the right type (be it an ID, a schema or a list of subjects) without needing to deal with the intermediary abstractions.

Regarding APIs, please note that I have excluded the registerIfLatest API from this PR because I am not convinced it is worth exposing this to end-users, and its semantics are unclear (the exact behavior is not entirely consistent across the code base). I'd like to evaluate the eventual inclusion (or exclusion) of the registerIfLatest API in a separate discussion. I believe the current set of proposed strongly-typed APIs should be merged in as is, even if registerIfLatest is excluded in the first iteration.

This is intended to be a building block towards creating an open-source self-service Kafka encoder/decoder implementation that allows versioned pub/sub without the headache.

As part of this work, the schema-repo-avro module was also introduced. This module contains an Avro-specific implementation of the Converter interface. It is isolated in its own module in order to keep the rest of the Schema Repo project serialization-agnostic. The schema-repo-api depends on schema-repo-avro for its tests only, but not for the main code.

Speaking of tests, some basic unit tests were written, but more should follow. That being said, considering the size of the changes involved, I'd like to merge this first iteration sooner than later, before it becomes too big. Once the new strongly-typed APIs are approved and merged in, then we can add more tests for all cases.

N.B.: The older String-based APIs remain available and it is not my intent to eliminate them. If anyone already has some code using those APIs, they should be able to continue doing so.

All comments and feedback welcome (:

Thanks!

-F