### PR TITLE
Porting run.sh  (obtained from 0.1.3-SNAPSHOT  )to window batch file 

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,37 @@
+@Echo on
+set JAVA_HOME=C:\Java\jdk1.6.0_45
+set MAVEN_HOME=C:\apacheMaven\apache-maven-3.2.1
+set MAVEN_OPTS=-Xms128m -Xmx512m
+set CLASSPATH=.;
+set PATH=%JAVA_HOME%\bin;%MAVEN_HOME%\bin
+
+@Echo off
+Echo.
+
+setlocal EnableDelayedExpansion
+
+if "%1"=="" GOTO Usage
+
+if "%1"=="in-memory" (
+     echo Starting Schema Repo Server with in In-Memory backend
+     java -cp bundle/target/schema-repo-bundle-*-withdeps.jar org.schemarepo.server.RepositoryServer bundle/config/in-memory-config.properties
+) else (
+        @if "%1"=="file-system" (
+             echo Starting Schema Repo Server with local file system backend
+             java -cp bundle/target/schema-repo-bundle-*-withdeps.jar org.schemarepo.server.RepositoryServer bundle/config/local-file-system-config.properties
+        ) else (
+                  @if "%1"=="zookeeper" (
+                        echo Starting Schema Repo Server with ZooKeeper backend
+                        java -cp zk-bundle/target/schema-repo-zk-bundle-*-withdeps.jar org.schemarepo.server.RepositoryServer zk-bundle/config/config.properties
+                  ) 
+        )
+)
+
+goto:eof
+
+
+:Usage
+Echo Usage: %0% ^<backend-type^>
+Echo.
+Echo backend-type : Specify which backend to run. Valid values are: in-memory, file-system and zookeeper.
+goto:eof


### PR DESCRIPTION
 Porting run.sh (obtained from 0.1.3-SNAPSHOT )to window batch file run.bat.

Testing environment settings are window 8.1 x64-based processor, JDK 1.6u45  and maven 3.2.1, netbeans 3.7.1
Testing Results:
Just testing batch script to bring up server without adding , deleting, retrieving schema with three back-ends ( in-memory, file-system and zookeeper) , servers were bounced up correctly, except zookeeper 's gave warning messages, which could be caused by missing zookeeper in window testing machine since  CentOS6.4 linux ( missing installation of zookeeper ) had same warning messages

Below are warnings:

WARN  [org.apache.zookeeper.ClientCnxn         ] Session 0x0 for server null, unexpected error, closing socket
connection and attempting reconnect
java.net.ConnectException: Connection refused: no further information
        at sun.nio.ch.SocketChannelImpl.checkConnect(Native Method) ~[na:1.6.0_45]
        at sun.nio.ch.SocketChannelImpl.finishConnect(SocketChannelImpl.java:599) ~[na:1.6.0_45]
        at org.apache.zookeeper.ClientCnxnSocketNIO.doTransport(ClientCnxnSocketNIO.java:361) ~[schema-repo-zk-bundle-0.
1.3-SNAPSHOT-withdeps.jar:0.1.3-SNAPSHOT]
        at org.apache.zookeeper.ClientCnxn$SendThread.run(ClientCnxn.java:1081) ~[schema-repo-zk-bundle-0.1.3-SNAPSHOT-w
ithdeps.jar:0.1.3-SNAPSHOT]