### PR TITLE
Issue #9: Further simplified the strongly-typed API.

### DIFF
--- a/api/src/main/java/org/schemarepo/api/TypedSchemaRepository.java
+++ b/api/src/main/java/org/schemarepo/api/TypedSchemaRepository.java
@@ -43,9 +43,9 @@ import com.google.common.collect.Lists;
  * N.B.2: registerIfLatest() is not supported in the TypedSchemaRepository,
  * at least for now...
  */
-public class TypedSchemaRepository<REPO extends Repository, ID, SCHEMA, SUBJECT> {
+public class TypedSchemaRepository<ID, SCHEMA, SUBJECT> {
 
-  private REPO repo;
+  private Repository repo;
   private Converter<ID> convertId;
   private Converter<SCHEMA> convertSchema;
   private Converter<SUBJECT> convertSubject;
@@ -58,7 +58,7 @@ public class TypedSchemaRepository<REPO extends Repository, ID, SCHEMA, SUBJECT>
   // Constructors
 
   public TypedSchemaRepository(
-          REPO repo,
+          Repository repo,
           Converter<ID> idConverter,
           Converter<SCHEMA> schemaConverter,
           Converter<SUBJECT> subjectConverter,
@@ -72,7 +72,7 @@ public class TypedSchemaRepository<REPO extends Repository, ID, SCHEMA, SUBJECT>
   }
 
   public TypedSchemaRepository(
-          REPO repo,
+          Repository repo,
           Converter<ID> idConverter,
           Converter<SCHEMA> schemaConverter,
           Converter<SUBJECT> subjectConverter) {

--- a/api/src/test/java/org/schemarepo/api/TestTypedSchemaRepository.java
+++ b/api/src/test/java/org/schemarepo/api/TestTypedSchemaRepository.java
@@ -101,8 +101,8 @@ public class TestTypedSchemaRepository {
     }
   }
 
-  private <INNER_REPO extends Repository, ID, SCHEMA, SUBJECT> void testRegistration(
-          INNER_REPO innerRepo,
+  private <ID, SCHEMA, SUBJECT> void testRegistration(
+          Repository innerRepo,
           Converter<ID> convertId,
           Converter<SCHEMA> convertSchema,
           Converter<SUBJECT> convertSubject) {
@@ -114,8 +114,8 @@ public class TestTypedSchemaRepository {
             convertSubject.getClass().getSimpleName() + "): ";
 
     try {
-      TypedSchemaRepository<INNER_REPO, ID, SCHEMA, SUBJECT> repo =
-              new TypedSchemaRepository<INNER_REPO, ID, SCHEMA, SUBJECT>
+      TypedSchemaRepository<ID, SCHEMA, SUBJECT> repo =
+              new TypedSchemaRepository<ID, SCHEMA, SUBJECT>
                       (innerRepo, convertId, convertSchema, convertSubject);
 
       SUBJECT subject1 = convertSubject.fromString("sub1");


### PR DESCRIPTION
The Repository's type is not used from any of the TypedSchemaRepository's APIs, so it is not necessary to make it part of the generic type definition.

Since this new API was introduced during 0.1.3-SNAPSHOT, and we haven't released 0.1.3 yet, I think it is worth making this change now.