### PR TITLE
Fix Issue 38 - support Default Subject Validators

### DIFF
--- a/common/src/main/java/org/schemarepo/RepositoryUtil.java
+++ b/common/src/main/java/org/schemarepo/RepositoryUtil.java
@@ -19,6 +19,8 @@
 package org.schemarepo;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
@@ -154,4 +156,39 @@ public final class RepositoryUtil {
     }
   }
 
+
+  /**
+   * Helper method for splitting a string by a delimiter with
+   * java.util.String.split().
+   * Omits empty values.
+   * @param toSplit The string to split.  If null, an empty
+   *   String[] is returned
+   * @return A String[] containing the non-empty values resulting
+   *   from the split.  Does not return null.
+   */
+  public static List<String> commaSplit(String toSplit) {
+    if (toSplit == null) {
+      return Collections.emptyList();
+    }
+    ArrayList<String> list = new ArrayList<String>();
+    for(String s : toSplit.split(",")) {
+      s = s.trim();
+      if (!s.isEmpty()) {
+        list.add(s);
+      }
+    }
+    return list;
+  }
+
+  public static String commaJoin(Collection<String> strings) {
+    StringBuilder sb = new StringBuilder();
+    for(String s : strings) {
+      sb.append(s).append(',');
+    }
+    // trim the trailing comma
+    if (sb.length() > 0)
+      return sb.substring(0,sb.length()-1);
+
+    return sb.toString();
+  }
 }

--- a/common/src/main/java/org/schemarepo/Subject.java
+++ b/common/src/main/java/org/schemarepo/Subject.java
@@ -219,7 +219,17 @@ public abstract class Subject {
     if (null == subject) {
       return subject;
     }
-    List<Validator> validators = factory.getValidators(subject.getConfig().getValidators());
+
+    List<Validator> validators;
+    SubjectConfig config = subject.getConfig();
+
+    // if the validators key is not specified in the subject config, get the default ones.
+    // ensure that even an empty set is honored as "no validators"
+    if (config.get(SubjectConfig.VALIDATORS_KEY) != null)
+      validators = factory.getValidators(config.getValidators());
+    else
+      validators = factory.getValidators(factory.getDefaultSubjectValidators());
+
     if (!validators.isEmpty()) {
       return new ValidatingSubject(subject, new CompositeValidator(validators));
     } else {

--- a/common/src/main/java/org/schemarepo/SubjectConfig.java
+++ b/common/src/main/java/org/schemarepo/SubjectConfig.java
@@ -18,12 +18,10 @@
 
 package org.schemarepo;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -36,6 +34,8 @@ import java.util.Set;
  */
 public class SubjectConfig {
   private static final SubjectConfig EMPTY = new Builder().build();
+  private static final String RESERVED_PREFIX = "repo.";
+  public static final String VALIDATORS_KEY = "repo.validators";
 
   private final Map<String, String> conf;
   private final Set<String> validators;
@@ -83,8 +83,6 @@ public class SubjectConfig {
   }
 
   public static class Builder {
-    private static final String RESERVED_PREFIX = "repo.";
-    private static final String VALIDATORS_KEY = "repo.validators";
 
     private final HashMap<String, String> conf = new HashMap<String, String>();
     private final HashSet<String> validators = new HashSet<String>();
@@ -99,7 +97,7 @@ public class SubjectConfig {
     public Builder set(String key, String value) {
       if(key.startsWith(RESERVED_PREFIX)) {
         if(VALIDATORS_KEY.equals(key)) {
-          setValidators(commaSplit(value));
+          setValidators(RepositoryUtil.commaSplit(value));
         } else {
           throw new RuntimeException("SubjectConfig keys starting with '" +
               RESERVED_PREFIX + "' are reserved, failed to set: " + key +
@@ -116,14 +114,15 @@ public class SubjectConfig {
       this.conf.remove(VALIDATORS_KEY);
       if(!validatorNames.isEmpty()) {
         this.validators.addAll(validatorNames);
-        this.conf.put(VALIDATORS_KEY, commaJoin(validators));
       }
+      // put the config entry even if they specified an empty list of validators. This is explicitly "no validators"
+      this.conf.put(VALIDATORS_KEY, RepositoryUtil.commaJoin(validators));
       return this;
     }
 
     public Builder addValidator(String validatorName) {
       this.validators.add(validatorName);
-      this.conf.put(VALIDATORS_KEY, commaJoin(validators));
+      this.conf.put(VALIDATORS_KEY, RepositoryUtil.commaJoin(validators));
       return this;
     }
 
@@ -135,35 +134,5 @@ public class SubjectConfig {
 
   }
 
-  /**
-   * Helper method for splitting a string by a delimiter with
-   * java.util.String.split().
-   * Omits empty values.
-   * @param toSplit The string to split.  If null, an empty
-   *   String[] is returned
-   * @return A String[] containing the non-empty values resulting
-   *   from the split.  Does not return null.
-   */
-  private static List<String> commaSplit(String toSplit) {
-    if (toSplit == null) {
-      return Collections.emptyList();
-    }
-    ArrayList<String> list = new ArrayList<String>();
-    for(String s : toSplit.split(",")) {
-      s = s.trim();
-      if (!s.isEmpty()) {
-        list.add(s);
-      }
-    }
-    return list;
-  }
-
-  private static String commaJoin(Collection<String> strings) {
-    StringBuilder sb = new StringBuilder();
-    for(String s : strings) {
-      sb.append(s).append(',');
-    }
-    return sb.toString();
-  }
 
 }

--- a/common/src/main/java/org/schemarepo/ValidatorFactory.java
+++ b/common/src/main/java/org/schemarepo/ValidatorFactory.java
@@ -19,7 +19,9 @@
 package org.schemarepo;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -33,9 +35,11 @@ public class ValidatorFactory {
   public static final ValidatorFactory EMPTY = new Builder().build();
 
   private final HashMap<String, Validator> validators;
+  private final Set<String> defaultSubjectValidators;
 
-  private ValidatorFactory(HashMap<String, Validator> validators) {
+  private ValidatorFactory(HashMap<String, Validator> validators, Set<String> defaultSubjectValidators) {
     this.validators = validators;
+    this.defaultSubjectValidators = defaultSubjectValidators;
   }
 
   /**
@@ -54,12 +58,23 @@ public class ValidatorFactory {
     return result;
   }
 
+  public final Set<String> getDefaultSubjectValidators() {
+    HashSet<String> result = new HashSet<String>(defaultSubjectValidators.size());
+    for (String name : defaultSubjectValidators) {
+      if (validators.containsKey(name))
+        result.add(name);
+    }
+    return result;
+  }
+
   public static class Builder {
     private final HashMap<String, Validator> validators;
     {
       validators = new HashMap<String, Validator>();
       validators.put(REJECT_VALIDATOR, new Reject());
     }
+
+    private final Set<String> defaultSubjectValidators = new HashSet<String>();
 
     /**
      * Configure this builder to return a {@link ValidatorFactory} that maps the
@@ -75,8 +90,20 @@ public class ValidatorFactory {
       return this;
     }
 
+    public Builder setDefaultValidator(String name) {
+      defaultSubjectValidators.add(name);
+      return this;
+    }
+
+    public Builder setDefaultValidators(Collection<String> validatorNames) {
+      for (String name : validatorNames) {
+        setDefaultValidator(name);
+      }
+      return this;
+    }
+
     public ValidatorFactory build() {
-      return new ValidatorFactory(new HashMap<String, Validator>(validators));
+      return new ValidatorFactory(new HashMap<String, Validator>(validators), new HashSet<String>(defaultSubjectValidators));
     }
   }
 

--- a/common/src/main/java/org/schemarepo/config/Config.java
+++ b/common/src/main/java/org/schemarepo/config/Config.java
@@ -33,6 +33,11 @@ public class Config {
   public static final String REPO_CACHE = GLOBAL_PREFIX + "cache";
   public static final String VALIDATOR_PREFIX = GLOBAL_PREFIX + "validator.";
 
+  // Validation class related configs
+  public static final String VALIDATION_PREFIX = GLOBAL_PREFIX + "validation.";
+  // The default list of validator names (not including prefix) to use for validating subjects.
+  public static final String DEFAULT_SUBJECT_VALIDATORS = VALIDATION_PREFIX + "default.validators";
+
   // Jetty configs
   private static final String JETTY_PREFIX = GLOBAL_PREFIX + "jetty.";
   public static final String JETTY_HOST = JETTY_PREFIX + "host";
@@ -84,6 +89,8 @@ public class Config {
     DEFAULTS.setProperty(JETTY_BUFFER_SIZE, "16384");
     DEFAULTS.setProperty(JETTY_STOP_AT_SHUTDOWN, "true");
     DEFAULTS.setProperty(JETTY_GRACEFUL_SHUTDOWN, "3000");
+
+    DEFAULTS.setProperty(DEFAULT_SUBJECT_VALIDATORS,"");
 
     // Logging defaults
     DEFAULTS.setProperty(LOGGING_ROUTE_JUL_TO_SLF4J, "true");

--- a/common/src/test/java/org/schemarepo/TestSubjectConfig.java
+++ b/common/src/test/java/org/schemarepo/TestSubjectConfig.java
@@ -54,12 +54,16 @@ public class TestSubjectConfig {
     SubjectConfig conf2 = new SubjectConfig.Builder()
       .set("repo.validators", null)
       .build();
-    Assert.assertEquals(conf, conf2);
-    Assert.assertEquals(conf2, empty);
+
+    // Explicitly setting empty or null validators is NOT the same as no validators
+    // due to the default subject validators functionality (see Issue 38)
+    Assert.assertNotEquals(conf, conf2);
+    Assert.assertNotEquals(conf2, empty);
+    Assert.assertNotEquals(conf.hashCode(), conf2.hashCode());
+
     Assert.assertFalse(conf.equals(null));
     Assert.assertFalse(conf.equals(new Object()));
     Assert.assertEquals(conf.hashCode(), empty.hashCode());
-    Assert.assertEquals(conf.hashCode(), conf2.hashCode());
 
     String k = "key";
     String v = "val";

--- a/server/src/main/java/org/schemarepo/config/ConfigModule.java
+++ b/server/src/main/java/org/schemarepo/config/ConfigModule.java
@@ -27,6 +27,7 @@ import javax.inject.Singleton;
 import org.schemarepo.CacheRepository;
 import org.schemarepo.Repository;
 import org.schemarepo.RepositoryCache;
+import org.schemarepo.RepositoryUtil;
 import org.schemarepo.Validator;
 import org.schemarepo.ValidatorFactory;
 import org.schemarepo.json.JsonUtil;
@@ -85,7 +86,7 @@ public class ConfigModule implements Module {
 
   @Provides
   @Singleton
-  ValidatorFactory provideValidatorFactory(Injector injector) {
+  ValidatorFactory provideValidatorFactory(Injector injector, @Named(Config.DEFAULT_SUBJECT_VALIDATORS) String defaultSubjectValidators) {
     ValidatorFactory.Builder builder = new ValidatorFactory.Builder();
     for(String prop : props.stringPropertyNames()) {
       if (prop.startsWith(Config.VALIDATOR_PREFIX)) {
@@ -96,6 +97,9 @@ public class ConfigModule implements Module {
         builder.setValidator(validatorName, injector.getInstance(validatorClass));
       }
     }
+
+    // assign the default subject validators
+    builder.setDefaultValidators(RepositoryUtil.commaSplit(defaultSubjectValidators));
     return builder.build();
   }
 


### PR DESCRIPTION
Implemented [Issue 38](https://github.com/schema-repo/schema-repo/issues/38) per comments in issue. Logic is contained within `ValidatorFactory` and `ValidatingSubject`. 
- Config setting is `"schema-repo.validation.default.validators"` and value is the comma delimited set of validator names (not including prefix) to use if no validators are specified in the Subject Config.
- Added a new @Named parameter to `ConfigModule#provideValidatorFactory`, parse names to `Set<String>` and extend Builder to configure the `DefaultSubjectValidators` in `ValidatorFactory`
- `ValidatingSubject` will inspect the `SubjectConfig` and if no validators are specified, it will use the ones in `ValidatorFactory#getDefaultSubjectValidators()`