### PR TITLE
Provide schema validation exceptions alongside 403

### DIFF
--- a/client/src/main/java/org/schemarepo/client/Avro1124RESTRepositoryClient.java
+++ b/client/src/main/java/org/schemarepo/client/Avro1124RESTRepositoryClient.java
@@ -154,7 +154,7 @@ public class Avro1124RESTRepositoryClient extends BaseRepository implements Repo
         ClientResponse cr = e.getResponse();
         if (ClientResponse.Status.fromStatusCode(cr.getStatus()).equals(
             ClientResponse.Status.FORBIDDEN)) {
-          throw new SchemaValidationException("Invalid schema: " + schema);
+          throw new SchemaValidationException("Invalid schema: " + schema + ". Reason: " + cr.getEntity(String.class));
         } else {
           //any other status should return null
           return null;

--- a/client/src/main/java/org/schemarepo/client/RESTRepositoryClient.java
+++ b/client/src/main/java/org/schemarepo/client/RESTRepositoryClient.java
@@ -208,7 +208,7 @@ public class RESTRepositoryClient extends BaseRepository implements RepositoryCl
       } catch (UniformInterfaceException e) {
         ClientResponse cr = e.getResponse();
         if (ClientResponse.Status.fromStatusCode(cr.getStatus()).equals(FORBIDDEN)) {
-          throw new SchemaValidationException("Invalid schema: " + schema);
+          throw new SchemaValidationException("Invalid schema: " + schema + ". Reason: " + cr.getEntity(String.class));
         } else {
           //any other status should return null
           handleException(e, format("Failed to register new schema for subject %s", getName()), resourceNotFoundExpected);

--- a/server/src/main/java/org/schemarepo/server/RESTRepository.java
+++ b/server/src/main/java/org/schemarepo/server/RESTRepository.java
@@ -195,9 +195,9 @@ public abstract class RESTRepository extends BaseRESTRepository {
    *          The subject name to register the schema in
    * @param schema
    *          The schema to register
-   * @return A 200 response with the corresponding id if successful, a 403
-   *         forbidden response if the schema fails validation, or a 404 not
-   *         found response if the subject does not exist
+   * @return A 200 response with the corresponding id if successful,
+   *         a 403 forbidden response with exception message if the schema fails validation,
+   *         or a 404 not found response if the subject does not exist
    */
   @PUT
   @Path("{subject}/register")
@@ -206,7 +206,7 @@ public abstract class RESTRepository extends BaseRESTRepository {
     try {
       return Response.ok(getSubject(subject).register(schema).getId()).build();
     } catch (SchemaValidationException e) {
-      return Response.status(Status.FORBIDDEN).build();
+      return Response.status(Status.FORBIDDEN).entity(e.getMessage()).build();
     }
   }
 
@@ -223,8 +223,8 @@ public abstract class RESTRepository extends BaseRESTRepository {
    *          the schema to attempt to register
    * @return a 200 response with the id of the newly registered schema, or a 404
    *         response if the subject or id does not exist or a 409 conflict if
-   *         the id does not match the latest id or a 403 forbidden response if
-   *         the schema failed validation
+   *         the id does not match the latest id or a 403 forbidden response
+   *         with exception message if the schema fails validation
    */
   @PUT
   @Path("{subject}/register_if_latest/{latestId: .*}")
@@ -246,7 +246,7 @@ public abstract class RESTRepository extends BaseRESTRepository {
       }
       return Response.ok(created.getId()).build();
     } catch (SchemaValidationException e) {
-      return Response.status(Status.FORBIDDEN).build();
+      return Response.status(Status.FORBIDDEN).entity(e.getMessage()).build();
     }
   }
 


### PR DESCRIPTION
When receiving a 403 Forbidden response code, I'd like to know what was the reason for `SchemaValidationException`.
